### PR TITLE
Update to Xcode 7 GM seed 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For more see:
 
 ### Requirements
 
-- [Xcode 7 Beta 5](https://developer.apple.com/xcode/downloads/)
+- [Xcode 7 GM seed 1](https://developer.apple.com/xcode/downloads/)
 - OS X 10.9+
     - This is due to Swift
 

--- a/SMCKitTool/main.swift
+++ b/SMCKitTool/main.swift
@@ -189,7 +189,7 @@ func printTemperatureInformation() {
 
         let smcKey  = CLIDisplayKeysOption.value ? "(\(sensor.code.toString()))" : ""
 
-        print("\(sensor.name + padding)   \(smcKey)  ", appendNewline: false)
+        print("\(sensor.name + padding)   \(smcKey)  ", terminator: "")
         print("\(color.rawValue)\(temperature)°C \(level)" +
               "\(ANSIColor.Off.rawValue)")
     }
@@ -229,7 +229,7 @@ func printUnknownTemperatureInformation() {
 
         let smcKey = CLIDisplayKeysOption.value ? "(\(sensor.code.toString()))" : ""
 
-        print("\(sensor.name)   \(smcKey)  ", appendNewline: false)
+        print("\(sensor.name)   \(smcKey)  ", terminator: "")
         print("\(color.rawValue)\(temperature)°C \(level)" +
               "\(ANSIColor.Off.rawValue)")
     }


### PR DESCRIPTION
`Apple Swift version 2.0 (swiftlang-700.0.59 clang-700.0.72)`

**Breaking changes**

- Via release notes
> `appendNewline: bool = true` was replaced with `terminator: String = "\n”`. Thus, `print(x, appendNewline: false)` becomes `print(x, terminator: "")`

* PR for updating CommandLine: https://github.com/jatoben/CommandLine/pull/29