### PR TITLE
Patch to Remove ANSI Colour Values Polluting Output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ nbproject
 *.sublime-project
 *.sublime-workspace
 /bin
+
+SMCKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist


### PR DESCRIPTION
Introduced polymorphic colour palette , which can be switch from a
default null palette to ANSI colours via -c option.

Needed because ANSI colours (OFF Colour) was polluting output all over
the plate even when -c option not used.